### PR TITLE
Switching formatting to a cleaner more readable type, cleaning up annotations. 

### DIFF
--- a/geometry.py
+++ b/geometry.py
@@ -1,12 +1,26 @@
 from annotation import label
 
 # Plot a line with arrows on both ends
-def plot_line(plt, start, end, txt= None):
-  plt.annotate(s='', xy=end, xytext=start, arrowprops=dict(arrowstyle='<->'))
 
-  if txt:
-    label(plt, txt, end)
+def plot_line(plt, start, end, txt=None):
+    plt.annotate(s="", xy=end, xytext=start, arrowprops=dict(arrowstyle="<->"))
+
+    if txt:
+        label(plt, txt, end)
+
 
 def plot_parallel(plt, point, arrow1, arrow2, color):
-  plt.annotate(s='', xy=arrow1, xytext=point, arrowprops=dict(arrowstyle='-|>', ec=[0, 0, 0, 0], fc=color, mutation_scale=15), zorder=5)
-  plt.annotate(s='', xy=arrow2, xytext=point, arrowprops=dict(          arrowstyle='-|>', ec=[0, 0, 0, 0], fc=color, mutation_scale=15), zorder=5)
+    plt.annotate(
+        s="",
+        xy=arrow1,
+        xytext=point,
+        arrowprops=dict(arrowstyle="-|>", ec=[0, 0, 0, 0], fc=color, mutation_scale=15),
+        zorder=5,
+    )
+    plt.annotate(
+        s="",
+        xy=arrow2,
+        xytext=point,
+        arrowprops=dict(arrowstyle="-|>", ec=[0, 0, 0, 0], fc=color, mutation_scale=15),
+        zorder=5,
+    )


### PR DESCRIPTION
Using 4 spaces per indentation level. It's easier to read, and people don't have to side scroll. The only thing I'd give you is any superfluous whitespaces, comments or other elements without syntactical meaning do not survive the tokenization step of the compilation, so in that varifocal I guess it doesn't matter. 